### PR TITLE
[MT-974] android fixes

### DIFF
--- a/Tealium/src/android/Extensions.kt
+++ b/Tealium/src/android/Extensions.kt
@@ -4,10 +4,7 @@ package com.tealium.cordova
 
 import android.app.Application
 import android.util.Log
-import com.tealium.collectdispatcher.CollectDispatcher
-import com.tealium.collectdispatcher.overrideCollectBatchUrl
-import com.tealium.collectdispatcher.overrideCollectDomain
-import com.tealium.collectdispatcher.overrideCollectUrl
+import com.tealium.collectdispatcher.*
 import com.tealium.core.*
 import com.tealium.core.collection.AppCollector
 import com.tealium.core.collection.ConnectivityCollector
@@ -23,6 +20,7 @@ import com.tealium.lifecycle.isAutoTrackingEnabled
 import com.tealium.remotecommanddispatcher.RemoteCommandDispatcher
 import com.tealium.tagmanagementdispatcher.TagManagementDispatcher
 import com.tealium.tagmanagementdispatcher.overrideTagManagementUrl
+import com.tealium.tagmanagementdispatcher.sessionCountingEnabled
 import com.tealium.visitorservice.VisitorProfile
 import com.tealium.visitorservice.VisitorService
 import org.json.JSONArray
@@ -84,7 +82,7 @@ fun JSONObject.toTealiumConfig(application: Application): TealiumConfig? {
     val dispatchers = optJSONArray(KEY_CONFIG_DISPATCHERS)?.toDispatcherFactories()
 
     val config = TealiumConfig(application, account, profile, environment,
-        collectors = collectors ?: Collectors.core,
+        collectors = collectors ?: Collectors.core.toMutableSet(),
         modules = modules ?: mutableSetOf(),
         dispatchers = dispatchers ?: mutableSetOf())
 
@@ -354,4 +352,8 @@ internal fun JSONObject.rename(oldKey: String, newKey: String) {
         this.put(newKey, it)
         this.remove(oldKey)
     }
+}
+
+internal fun Set<ConsentCategory>.toJsonArray(): JSONArray {
+    return JSONArray(this.map { it.value })
 }

--- a/Tealium/src/android/TealiumCordova.kt
+++ b/Tealium/src/android/TealiumCordova.kt
@@ -5,7 +5,6 @@ import com.tealium.core.Logger
 import com.tealium.core.Tealium
 import com.tealium.core.consent.ConsentCategory
 import com.tealium.core.consent.ConsentStatus
-import com.tealium.core.consent.toJsonArray
 import com.tealium.core.messaging.UserConsentPreferencesUpdatedListener
 import com.tealium.lifecycle.isAutoTrackingEnabled
 import com.tealium.lifecycle.lifecycle
@@ -293,9 +292,11 @@ class TealiumCordova @JvmOverloads constructor(
 
     fun gatherTrackData(callbackContext: CallbackContext?) {
         tealium?.apply {
-            callbackContext.sendPluginResult(
-                PluginResult.Status.OK,
-                gatherTrackData()
+            callbackContext?.sendPluginResult(
+                PluginResult(
+                    PluginResult.Status.OK,
+                    JSONObject(gatherTrackData())
+                )
             )
         }
     } 

--- a/TealiumCordovaSample/config.xml
+++ b/TealiumCordovaSample/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.tealium.example" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.tealium.example" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>TealiumCordovaSample</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.
@@ -18,6 +18,9 @@
     <platform name="android">
         <allow-intent href="market:*" />
         <preference name="AndroidXEnabled" value="true" />
+        <preference name="android-targetSdkVersion" value="31" />
+        <preference name="android-compileSdkVersion" value="31" />
+        <preference name="android-buildToolsVersion" value="30.0.3" />
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
              <!-- TODO: Replace with your real AdMob app ID -->
             <meta-data android:name="com.google.android.gms.ads.APPLICATION_ID" android:value="ca-app-pub-################~##########" />

--- a/TealiumCordovaSample/www/js/index.js
+++ b/TealiumCordovaSample/www/js/index.js
@@ -146,8 +146,15 @@ function logConsentExpired() {
 }
 
 function createRemoteCommands() {
-    return [
-        window.tealium.remotecommands.firebase.create()
-            .setPath("firebase.json")
-    ]
+    var commands = [];
+    var remoteCommands = window.tealium && 
+                            window.tealium.remotecommands;
+    if (remoteCommands) {
+        var firebase =  remoteCommands.firebase && 
+                            remoteCommands.firebase.create()
+                                .setPath("firebase.json");
+        firebase && commands.push(firebase);
+    }
+
+    return commands;
 }


### PR DESCRIPTION
 - A couple of updates relating to changes brought in by Kotlin SDK 1.4.2 
 - Fix for the `sendPluginResult` for `gatherTrackData` as it wouldn't build
 - TealiumCordovaSample `config.xml` Android xml schema definition added, as failed gradle build without 
 - Update to TealiumCordovaSample `index.js` to more safely add the firebase remote command if it's availble