### PR TITLE
Map handling

### DIFF
--- a/Tealium/package.json
+++ b/Tealium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tealium-cordova-plugin",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Tealium Customer Data Hub",
   "cordova": {
     "id": "tealium-cordova-plugin",

--- a/Tealium/plugin.xml
+++ b/Tealium/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="tealium-cordova-plugin" version="2.3.0" 
+        id="tealium-cordova-plugin" version="2.3.1" 
 name="tealium-cordova-plugin">
 
     <name>TealiumCordova</name>

--- a/Tealium/www/tealium.js
+++ b/Tealium/www/tealium.js
@@ -98,6 +98,22 @@ const Dispatch = {
     }
 };
 
+const mapToObject = function (entries){
+    if (!entries || !entries[Symbol.iterator]) {
+        return {};
+    }
+
+    let obj = {};
+    for (let [key, value] of entries) {
+        if (value && value instanceof Map) {
+            obj[key] = mapToObject(value);
+        } else {
+            obj[key] = value;
+        }
+    }
+    return obj;
+};
+
 const Commands = {
     INITIALIZE: "initialize",
     TRACK: "track",
@@ -142,7 +158,7 @@ let TealiumPlugin = {
     initialize(config, callback) {
         let self = this;
         cordova.exec(function(e) {
-            self.addData({'plugin_name': 'Tealium-Cordova', 'plugin_version': '2.3.0'}, Expiry.forever);
+            self.addData({'plugin_name': 'Tealium-Cordova', 'plugin_version': '2.3.1'}, Expiry.forever);
             if (config.remoteCommands) {
                 config.remoteCommands.forEach((remoteCommand) => {
                     self.addRemoteCommand(remoteCommand.id, remoteCommand.callback, remoteCommand.path, remoteCommand.url)
@@ -156,6 +172,10 @@ let TealiumPlugin = {
     },
 
     track(dispatch) {
+        if (dispatch.dataLayer && dispatch.dataLayer instanceof Map) {
+            // Ionic supports sending `Map<String, Any>`
+            dispatch.dataLayer = mapToObject(dispatch.dataLayer)
+        }
         cordova.exec(null, null, PLUGIN_NAME, Commands.TRACK, [dispatch])
     },
 
@@ -164,6 +184,10 @@ let TealiumPlugin = {
     },
 
     addData(data, expiry) {
+        if (data && data instanceof Map) {
+            // Ionic supports sending `Map<String, Any>`
+            data = mapToObject(data)
+        }
         cordova.exec(null, null, PLUGIN_NAME, Commands.ADD_DATA, [data, expiry])
     },
 


### PR DESCRIPTION
 - v2.3.1
 - Handling of `Map` type entered into `addData` and `track` methods, mainly from [Ionic Typescript](https://github.com/danielsogl/awesome-cordova-plugins/blob/master/src/%40awesome-cordova-plugins/plugins/tealium/index.ts#L37) wrapper; conversion is adapted from `Object.fromEntries` polyfill

 - Testable locally by following code snippets when debugging via DevTools
```js
tealium.track(
    tealium.utils.Dispatch.event("map", new Map([
        ["map_key", "map_value"]
    ]))
)
```
Conversion to objects does support nested maps, although support for nested objects elsewhere in the system is limited anyway.
```js
tealium.track(
    tealium.utils.Dispatch.event("map", new Map([
        ["map_key", "map_value"],
        ["submap", new Map([
            ["submap_key", "submap_data"]
        ])]
    ]))
)
```