### PR TITLE
[MT-1982] Add support for SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ platforms/
 package-lock.json
 *GoogleService-Info.plist
 *google-services.json
+.build/
+.swiftpm/
+Package.resolved

--- a/RemoteCommands/TealiumFirebase/Package.swift
+++ b/RemoteCommands/TealiumFirebase/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "tealium-cordova-firebase-plugin",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(name: "tealium-cordova-firebase-plugin", targets: ["tealium-cordova-firebase-plugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
+        .package(url: "https://github.com/tealium/tealium-swift.git", .upToNextMajor(from: "2.18.0")),
+        .package(url: "https://github.com/tealium/tealium-ios-firebase-remote-command.git", .upToNextMajor(from: "3.2.0")),
+        // cordova-ios 8+ always installs plugins as siblings under platforms/ios/packages/
+        .package(name: "tealium-cordova-plugin", path: "../tealium-cordova-plugin")
+    ],
+    targets: [
+        .target(
+            name: "tealium-cordova-firebase-plugin",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "TealiumCore", package: "tealium-swift"),
+                .product(name: "TealiumRemoteCommands", package: "tealium-swift"),
+                .product(name: "TealiumFirebase", package: "tealium-ios-firebase-remote-command"),
+                .product(name: "tealium-cordova-plugin", package: "tealium-cordova-plugin")
+            ],
+            path: "src/ios"
+        )
+    ]
+)

--- a/RemoteCommands/TealiumFirebase/plugin.xml
+++ b/RemoteCommands/TealiumFirebase/plugin.xml
@@ -20,7 +20,7 @@
     </js-module>
 
     <!-- ios -->
-    <platform name="ios">
+    <platform name="ios" package="swift">
         <plugins-plist key="TealiumFirebase" string="TealiumFirebase" />
         <config-file target="config.xml" parent="/*">
             <plugin name="TealiumFirebase" value="TealiumFirebase"/>
@@ -36,10 +36,10 @@
         <framework src="SystemConfiguration.framework" />
         <podspec>
           <pods use-frameworks="true">
-            <pod name="TealiumFirebase" spec="~> 3.2"/>
-            <pod name="Firebase" spec="~> 10.7"/>
-            <pod name="FirebaseAnalytics" spec="~> 10.7"/>
-          </pods> 
+            <pod name="TealiumFirebase" spec="~> 3.2" nospm="true"/>
+            <pod name="Firebase" spec="~> 10.7" nospm="true"/>
+            <pod name="FirebaseAnalytics" spec="~> 10.7" nospm="true"/>
+          </pods>
         </podspec>
     </platform>
     <!-- android -->

--- a/RemoteCommands/TealiumFirebase/src/ios/FirebaseRemoteCommandWrapper.swift
+++ b/RemoteCommands/TealiumFirebase/src/ios/FirebaseRemoteCommandWrapper.swift
@@ -6,7 +6,16 @@
 //  Created by James Keith on 09/09/2021.
 //
 import Foundation
+#if canImport(Cordova)
+import Cordova
+#endif
+#if canImport(TealiumSwift)
 import TealiumSwift
+#else
+import TealiumCore
+import TealiumRemoteCommands
+import tealium_cordova_plugin
+#endif
 import TealiumFirebase
 
 class FirebaseRemoteCommandWrapper: RemoteCommandFactory {

--- a/RemoteCommands/TealiumFirebase/src/ios/TealiumFirebase.swift
+++ b/RemoteCommands/TealiumFirebase/src/ios/TealiumFirebase.swift
@@ -6,7 +6,15 @@
 //
 
 import Foundation
+#if canImport(Cordova)
+import Cordova
+#endif
+#if canImport(TealiumSwift)
 import TealiumSwift
+#else
+import TealiumCore
+import tealium_cordova_plugin
+#endif
 
 @objc(TealiumFirebase)
 class TealiumFirebase: CDVPlugin {

--- a/Tealium/Package.swift
+++ b/Tealium/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "tealium-cordova-plugin",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(name: "tealium-cordova-plugin", targets: ["tealium-cordova-plugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
+        .package(url: "https://github.com/tealium/tealium-swift.git", .upToNextMajor(from: "2.18.0"))
+    ],
+    targets: [
+        .target(
+            name: "tealium-cordova-plugin",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "TealiumCore", package: "tealium-swift"),
+                .product(name: "TealiumCollect", package: "tealium-swift"),
+                .product(name: "TealiumTagManagement", package: "tealium-swift"),
+                .product(name: "TealiumLifecycle", package: "tealium-swift"),
+                .product(name: "TealiumRemoteCommands", package: "tealium-swift"),
+                .product(name: "TealiumVisitorService", package: "tealium-swift")
+            ],
+            path: "src/ios"
+        )
+    ]
+)

--- a/Tealium/plugin.xml
+++ b/Tealium/plugin.xml
@@ -21,7 +21,7 @@ name="tealium-cordova-plugin">
     </js-module>
 
     <!-- ios -->
-    <platform name="ios">
+    <platform name="ios" package="swift">
         <!-- Cordova < 2.3 -->
         <plugins-plist key="TealiumCordova" string="TealiumCordova" />
         <!-- Cordova >= 2.3 -->
@@ -43,13 +43,13 @@ name="tealium-cordova-plugin">
         <framework src="SystemConfiguration.framework" />
         <podspec>
           <pods use-frameworks="true">
-            <pod name="tealium-swift/Core" spec="~> 2.18"/>
-            <pod name="tealium-swift/TagManagement" spec="~> 2.18"/>
-            <pod name="tealium-swift/Collect" spec="~> 2.18"/>
-            <pod name="tealium-swift/Lifecycle" spec="~> 2.18"/>
-            <pod name="tealium-swift/RemoteCommands" spec="~> 2.18"/>
-            <pod name="tealium-swift/VisitorService" spec="~> 2.18"/>
-          </pods> 
+            <pod name="tealium-swift/Core" spec="~> 2.18" nospm="true"/>
+            <pod name="tealium-swift/TagManagement" spec="~> 2.18" nospm="true"/>
+            <pod name="tealium-swift/Collect" spec="~> 2.18" nospm="true"/>
+            <pod name="tealium-swift/Lifecycle" spec="~> 2.18" nospm="true"/>
+            <pod name="tealium-swift/RemoteCommands" spec="~> 2.18" nospm="true"/>
+            <pod name="tealium-swift/VisitorService" spec="~> 2.18" nospm="true"/>
+          </pods>
         </podspec>
     </platform>
     <!-- android -->

--- a/Tealium/src/ios/RemoteCommandFactory.swift
+++ b/Tealium/src/ios/RemoteCommandFactory.swift
@@ -5,9 +5,14 @@
 //  Created by James Keith on 08/04/2021.
 //
 import Foundation
+#if canImport(TealiumSwift)
 import TealiumSwift
+#else
+import TealiumCore
+import TealiumRemoteCommands
+#endif
 
-protocol RemoteCommandFactory {
+public protocol RemoteCommandFactory {
     var name: String { get }
     func create() -> RemoteCommand
 }

--- a/Tealium/src/ios/TealiumCordova.swift
+++ b/Tealium/src/ios/TealiumCordova.swift
@@ -118,8 +118,8 @@ class TealiumCordova: CDVPlugin {
         let url = command.argument(at: 2) as? String
         TealiumPlugin.addRemoteCommand(id: id, callbackId: command.callbackId, path: path, url: url)
         
-        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result.keepCallback = true
+        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        result?.keepCallback = true
         self.commandDelegate.send(result, callbackId: command.callbackId)
     }
 
@@ -206,8 +206,8 @@ class TealiumCordova: CDVPlugin {
         }
         TealiumPlugin.setConsentExpiryListener(callbackId: callbackId)
         
-        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result.keepCallback = true
+        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        result?.keepCallback = true
         self.commandDelegate.send(result, callbackId: command.callbackId)
     }
     
@@ -218,8 +218,8 @@ class TealiumCordova: CDVPlugin {
         }
         TealiumPlugin.setVisitorServiceListener(callbackId: callbackId)
         
-        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result.keepCallback = true
+        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        result?.keepCallback = true
         self.commandDelegate.send(result, callbackId: command.callbackId)
     }
     
@@ -230,8 +230,8 @@ class TealiumCordova: CDVPlugin {
         }
         TealiumPlugin.setVisitorIdListener(callbackId: callbackId)
         
-        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result.keepCallback = true
+        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        result?.keepCallback = true
         self.commandDelegate.send(result, callbackId: command.callbackId)
     }
     

--- a/Tealium/src/ios/TealiumCordova.swift
+++ b/Tealium/src/ios/TealiumCordova.swift
@@ -118,9 +118,8 @@ class TealiumCordova: CDVPlugin {
         let url = command.argument(at: 2) as? String
         TealiumPlugin.addRemoteCommand(id: id, callbackId: command.callbackId, path: path, url: url)
         
-        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result?.keepCallback = true
-        self.commandDelegate.send(result, callbackId: command.callbackId)
+        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        self.commandDelegate.sendListenerResult(result, callbackId: command.callbackId)
     }
 
     @objc(removeRemoteCommand:)
@@ -206,9 +205,8 @@ class TealiumCordova: CDVPlugin {
         }
         TealiumPlugin.setConsentExpiryListener(callbackId: callbackId)
         
-        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result?.keepCallback = true
-        self.commandDelegate.send(result, callbackId: command.callbackId)
+        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        self.commandDelegate.sendListenerResult(result, callbackId: command.callbackId)
     }
     
     @objc(setVisitorServiceListener:)
@@ -218,9 +216,8 @@ class TealiumCordova: CDVPlugin {
         }
         TealiumPlugin.setVisitorServiceListener(callbackId: callbackId)
         
-        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result?.keepCallback = true
-        self.commandDelegate.send(result, callbackId: command.callbackId)
+        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        self.commandDelegate.sendListenerResult(result, callbackId: command.callbackId)
     }
     
     @objc(setVisitorIdListener:)
@@ -230,9 +227,8 @@ class TealiumCordova: CDVPlugin {
         }
         TealiumPlugin.setVisitorIdListener(callbackId: callbackId)
         
-        let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-        result?.keepCallback = true
-        self.commandDelegate.send(result, callbackId: command.callbackId)
+        let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+        self.commandDelegate.sendListenerResult(result, callbackId: command.callbackId)
     }
     
     @objc(removeListeners:)

--- a/Tealium/src/ios/TealiumCordova.swift
+++ b/Tealium/src/ios/TealiumCordova.swift
@@ -6,7 +6,14 @@
 //
 
 import Foundation
+#if canImport(Cordova)
+import Cordova
+#endif
+#if canImport(TealiumSwift)
 import TealiumSwift
+#else
+import TealiumCore
+#endif
 
 @objc(TealiumCordova)
 class TealiumCordova: CDVPlugin {

--- a/Tealium/src/ios/TealiumPlugin.swift
+++ b/Tealium/src/ios/TealiumPlugin.swift
@@ -200,19 +200,19 @@ public class TealiumPlugin: NSObject {
     public static func removeListeners() {
         visitorServiceCallbackIds.forEach { callbackId in
             let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
+            commandDelegate?.send(result, callbackId: callbackId)
         }
         visitorServiceCallbackIds.removeAll()
         
         consentExpiryCallbackIds.forEach { callbackId in
             let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
+            commandDelegate?.send(result, callbackId: callbackId)
         }
         consentExpiryCallbackIds.removeAll()
         
         visitorIdCallbackIds.forEach { callbackId in
             let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
+            commandDelegate?.send(result, callbackId: callbackId)
         }
         visitorIdCallbackIds.removeAll()
     }

--- a/Tealium/src/ios/TealiumPlugin.swift
+++ b/Tealium/src/ios/TealiumPlugin.swift
@@ -34,8 +34,8 @@ public class TealiumPlugin: NSObject {
     
     static var visitorServiceDelegate: VisitorServiceDelegate = VisitorDelegate(didUpdate: { visitor in
         visitorServiceCallbackIds.forEach { callbackId in
-            let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: visitor)
-            result.keepCallback = true
+            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: visitor)
+            result?.keepCallback = true
             commandDelegate?.send(result, callbackId: callbackId)
         }
     })
@@ -79,8 +79,8 @@ public class TealiumPlugin: NSObject {
         tealium = Tealium(config: localConfig) { _ in
             tealium?.onVisitorId?.subscribe { id in
                 visitorIdCallbackIds.forEach { callbackId in
-                    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: id)
-                    result.keepCallback = true
+                    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: id)
+                    result?.keepCallback = true
                     commandDelegate?.send(result, callbackId: callbackId)
                 }
             }
@@ -201,22 +201,22 @@ public class TealiumPlugin: NSObject {
     @objc
     public static func removeListeners() {
         visitorServiceCallbackIds.forEach { callbackId in
-            let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            result.keepCallback = false
+            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+            result?.keepCallback = false
             commandDelegate?.send(result, callbackId: callbackId)
         }
         visitorServiceCallbackIds.removeAll()
         
         consentExpiryCallbackIds.forEach { callbackId in
-            let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            result.keepCallback = false
+            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+            result?.keepCallback = false
             commandDelegate?.send(result, callbackId: callbackId)
         }
         consentExpiryCallbackIds.removeAll()
         
         visitorIdCallbackIds.forEach { callbackId in
-            let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            result.keepCallback = false
+            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+            result?.keepCallback = false
             commandDelegate?.send(result, callbackId: callbackId)
         }
         visitorIdCallbackIds.removeAll()

--- a/Tealium/src/ios/TealiumPlugin.swift
+++ b/Tealium/src/ios/TealiumPlugin.swift
@@ -6,10 +6,22 @@
 //
 
 import Foundation
+#if canImport(Cordova)
+import Cordova
+#endif
+#if canImport(TealiumSwift)
 import TealiumSwift
+#else
+import TealiumCore
+import TealiumCollect
+import TealiumTagManagement
+import TealiumLifecycle
+import TealiumRemoteCommands
+import TealiumVisitorService
+#endif
 
 @objc
-class TealiumPlugin: NSObject {
+public class TealiumPlugin: NSObject {
     
     
     static var tealium: Tealium?

--- a/Tealium/src/ios/TealiumPlugin.swift
+++ b/Tealium/src/ios/TealiumPlugin.swift
@@ -34,9 +34,8 @@ public class TealiumPlugin: NSObject {
     
     static var visitorServiceDelegate: VisitorServiceDelegate = VisitorDelegate(didUpdate: { visitor in
         visitorServiceCallbackIds.forEach { callbackId in
-            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: visitor)
-            result?.keepCallback = true
-            commandDelegate?.send(result, callbackId: callbackId)
+            let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: visitor)
+            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
         }
     })
     
@@ -79,9 +78,8 @@ public class TealiumPlugin: NSObject {
         tealium = Tealium(config: localConfig) { _ in
             tealium?.onVisitorId?.subscribe { id in
                 visitorIdCallbackIds.forEach { callbackId in
-                    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: id)
-                    result?.keepCallback = true
-                    commandDelegate?.send(result, callbackId: callbackId)
+                    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: id)
+                    commandDelegate?.sendListenerResult(result, callbackId: callbackId)
                 }
             }
             completion(true)
@@ -201,23 +199,20 @@ public class TealiumPlugin: NSObject {
     @objc
     public static func removeListeners() {
         visitorServiceCallbackIds.forEach { callbackId in
-            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            result?.keepCallback = false
-            commandDelegate?.send(result, callbackId: callbackId)
+            let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
         }
         visitorServiceCallbackIds.removeAll()
         
         consentExpiryCallbackIds.forEach { callbackId in
-            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            result?.keepCallback = false
-            commandDelegate?.send(result, callbackId: callbackId)
+            let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
         }
         consentExpiryCallbackIds.removeAll()
         
         visitorIdCallbackIds.forEach { callbackId in
-            let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
-            result?.keepCallback = false
-            commandDelegate?.send(result, callbackId: callbackId)
+            let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+            commandDelegate?.sendListenerResult(result, callbackId: callbackId)
         }
         visitorIdCallbackIds.removeAll()
     }

--- a/Tealium/src/ios/TealiumPluginExtensions.swift
+++ b/Tealium/src/ios/TealiumPluginExtensions.swift
@@ -40,9 +40,8 @@ extension TealiumPlugin {
             localConfig.consentLoggingEnabled =  dictionary[.consentLoggingEnabled] as? Bool ?? true
             localConfig.onConsentExpiration = {
                 consentExpiryCallbackIds.forEach { callbackId in
-                    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK)
-                    result?.keepCallback = true
-                    commandDelegate?.send(result, callbackId: callbackId)
+                    let result = CDVPluginResult(status: CDVCommandStatus_OK)
+                    commandDelegate?.sendListenerResult(result, callbackId: callbackId)
                 }
             }
         }
@@ -231,9 +230,8 @@ extension TealiumPlugin {
                     return
                 }
                 guard let payload = response.payload else { return }
-                let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: payload)
-                result?.keepCallback = true
-                commandDelegate.send(result, callbackId: callbackId)
+                let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: payload)
+                commandDelegate.sendListenerResult(result, callbackId: callbackId)
             }
         }
             
@@ -322,5 +320,15 @@ class VisitorDelegate: VisitorServiceDelegate {
             Visitor.currentVisit: visit.compactMapValues { $0 }
         ]
         return visitor.compactMapValues({$0})
+    }
+}
+
+extension CDVCommandDelegate {
+    /// Utility method to send results to listeners that must keep the callback alive.
+    /// Result is optional for backwards compatibility with Cordova 7.
+    func sendListenerResult(_ result: CDVPluginResult?, callbackId: String) {
+        guard let result else { return }
+        result.keepCallback = true
+        self.send(result, callbackId: callbackId)
     }
 }

--- a/Tealium/src/ios/TealiumPluginExtensions.swift
+++ b/Tealium/src/ios/TealiumPluginExtensions.swift
@@ -6,7 +6,19 @@
 //
 
 import Foundation
+#if canImport(Cordova)
+import Cordova
+#endif
+#if canImport(TealiumSwift)
 import TealiumSwift
+#else
+import TealiumCore
+import TealiumCollect
+import TealiumTagManagement
+import TealiumLifecycle
+import TealiumRemoteCommands
+import TealiumVisitorService
+#endif
 
 extension TealiumPlugin {
     

--- a/Tealium/src/ios/TealiumPluginExtensions.swift
+++ b/Tealium/src/ios/TealiumPluginExtensions.swift
@@ -40,8 +40,8 @@ extension TealiumPlugin {
             localConfig.consentLoggingEnabled =  dictionary[.consentLoggingEnabled] as? Bool ?? true
             localConfig.onConsentExpiration = {
                 consentExpiryCallbackIds.forEach { callbackId in
-                    let result = CDVPluginResult(status: CDVCommandStatus_OK)
-                    result.keepCallback = true
+                    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK)
+                    result?.keepCallback = true
                     commandDelegate?.send(result, callbackId: callbackId)
                 }
             }
@@ -231,8 +231,8 @@ extension TealiumPlugin {
                     return
                 }
                 guard let payload = response.payload else { return }
-                let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: payload)
-                result.keepCallback = true
+                let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: payload)
+                result?.keepCallback = true
                 commandDelegate.send(result, callbackId: callbackId)
             }
         }

--- a/TealiumCordovaSample/config.xml
+++ b/TealiumCordovaSample/config.xml
@@ -38,7 +38,7 @@
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
-        <preference name="deployment-target" value="13.0" />
+        <preference name="deployment-target" value="15.0" />
         <preference name="target-device" value="universal" />
         <resource-file src="resources/firebase.json" />
         <!-- uncomment the following to test Firebase after adding the GoogleService-Info.plist under the resources directory -->


### PR DESCRIPTION
## Summary

- Add Swift Package Manager support for both `tealium-cordova-plugin` and `tealium-cordova-firebase-plugin` on cordova-ios 8+
- Maintain full backward compatibility with cordova-ios 7 (CocoaPods)
- Fix `CDVPluginResult` optionality differences between cordova-ios 7 and 8

## How it works

On **cordova-ios 8+**: the `package="swift"` attribute in `plugin.xml` tells Cordova to use SPM. Pods marked with `nospm="true"` are skipped. The plugin's `Package.swift` declares all dependencies and Xcode resolves them at build time.

On **cordova-ios 7** (or earlier): `package="swift"` and `nospm="true"` are silently ignored. CocoaPods installs everything as before. No customer action required.

## Key decisions

- **`#if canImport(TealiumSwift)` conditional imports**: CocoaPods creates a single `TealiumSwift` umbrella module, but SPM exposes individual modules (`TealiumCore`, `TealiumCollect`, etc.). The conditional handles both without breaking either path.

- **`#if canImport(Cordova)` for the Cordova import**: Under CocoaPods (cordova-ios 7), `CDVPlugin` types are available via the bridging header without an explicit import. Under SPM they require `import Cordova`. The `canImport` check makes this safe for both.

- **Inter-plugin dependency via local path** (`path: "../tealium-cordova-plugin"` in Firebase's Package.swift): SPM isolates each package, so the Firebase plugin can't see `TealiumPlugin` or `RemoteCommandFactory` from the main plugin without an explicit dependency. This relative path works because cordova-ios 8 always installs plugins as siblings under `platforms/ios/packages/`. This is the same pattern cordova-ios uses internally for `cordova-ios-plugins` → `cordova-ios`.

- **`public` access on `TealiumPlugin` class and `RemoteCommandFactory` protocol**: Required for cross-module visibility under SPM. Under CocoaPods (same module) this has no effect.

- **`sendListenerResult` extension on `CDVCommandDelegate`**: In cordova-ios 7, `CDVPluginResult(status:)` returns `CDVPluginResult?`. In cordova-ios 8, it returns `CDVPluginResult`. The extension accepts an optional, unwraps it, sets `keepCallback = true`, and calls `send` — compiling cleanly on both versions. 
The name here was chosen to highlight the fact that this send, that sets keepCallback internally, is only for listeners, which all need to keep the callback, as the callback itself might be called again later.

## Notes

1. **Deployment target must be ≥ 15.0 when using the Firebase plugin with SPM** — because `tealium-ios-firebase-remote-command` requires iOS 15. SPM enforces this transitively. Customers need `<preference name="deployment-target" value="15.0" />` in their `config.xml`. This was already effectively required by the Firebase SDK under CocoaPods too, just not as strictly enforced.

2. **The Firebase `Package.swift` declares `platforms: [.iOS(.v15)]`** but the CordovaPlugins umbrella package inherits the app's deployment target. If the app sets a target below 15, the build will fail with a clear error message.

3. **`.build/` directories must not exist in the plugin source** when Cordova copies it to `platforms/ios/packages/`. The IDE's SPM indexer can create these with broken symlinks (e.g., gRPC xcframework). The `.gitignore` covers this for git, but local development environments should be aware.

4. **SPM and CocoaPods can coexist in the same cordova-ios 8 project** — our SPM plugins don't prevent other plugins from using CocoaPods. Each plugin is handled independently based on its own `package="swift"` attribute.

5. **The `removeListeners` method now doesn't set `keepCallback = false`** because it's already false by default.

## Test plan

- [x] Build with cordova-ios 7.1.1 + CocoaPods → BUILD SUCCEEDED
- [x] Build with cordova-ios 8.0.1 + SPM → BUILD SUCCEEDED
- [x] Verified Podfile is empty on cordova-ios 8 (pods skipped via `nospm="true"`)
- [x] Verified SPM resolves `tealium-swift@2.18.3` and `tealium-ios-firebase-remote-command@3.4.0`
- [x] Verified mixing SPM plugins with CocoaPods plugins works on cordova-ios 8